### PR TITLE
Add ansible skeleton and todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# syshaldus
+# Syshaldus
+
+Ansible playbooks for the System Administration course labs.
+
+See [TODO.md](TODO.md) for the list of tasks.
+
+To run all roles:
+
+```bash
+cd ansible
+ansible-playbook site.yml
+```
+
+Run a single part using tags:
+
+```bash
+ansible-playbook site.yml --tags web
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,82 @@
+# TODO List for System Administration Labs 1-12
+
+This repository contains Ansible playbooks for automating tasks from the University of Tartu System Administration course.
+
+## Lab 1 – Introduction
+- Remembering *NIX basics
+- Complete the CTF exercise
+- Access the sandbox machine
+
+## Lab 2 – ETAIS setup
+- Generate SSH key pair and upload public key
+- Create a virtual machine
+- Configure VPN client
+- Add root and scoring accounts
+- Set up backups
+- Configure security groups and update packages
+
+## Lab 3 – Ansible
+- Install Ansible locally
+- Create the folder structure for playbooks
+- Write your first playbook and roles
+- Store the code in Git
+
+## Lab 4 – DNS
+- Install and configure BIND
+- Open firewall port 53
+- Disable IPv6
+- Automate DNS setup with Ansible
+
+## Lab 5 – Web services
+- Install Apache and PHP
+- Set up WordPress site
+- Configure Apache modules and virtual hosts
+- Automate web server setup with Ansible
+
+## Lab 6 – Email
+- Add MX record to DNS
+- Install Postfix and Dovecot
+- Provide webmail access
+- Automate mail server setup
+
+## Lab 7 – TLS
+- Request and install certificates
+- Enable HTTPS in Apache
+- Secure Postfix and Dovecot with TLS
+- Automate certificate deployment with Ansible
+
+## Lab 8 – Filesystems
+- Explore EXT4, XFS and BTRFS
+- Configure NFS and Samba shares
+- Try object storage
+
+## Lab 9 – Containers
+- Install Docker
+- Build and run containers
+- Persist data
+- Automate container tasks with Ansible
+
+## Lab 10 – DevOps
+- Debug and link containers
+- Publish container images
+- Deploy with Docker networks
+
+## Lab 11 – Kubernetes
+- Run a simple pod and deployment
+- Configure services and ingress
+- Use volumes
+- Automate with Ansible
+
+## Lab 12 – Monitoring
+- Set up Rsyslog
+- Collect metrics with Prometheus
+- Visualise with Grafana
+- Centralise logs
+
+Run specific parts of the infrastructure using tags, for example:
+
+```bash
+ansible-playbook site.yml --tags email
+```
+
+If any configuration (such as WordPress initial setup) requires manual action, you will be prompted during playbook execution.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = inventory/hosts.ini
+roles_path = roles

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/ansible/roles/dns/tasks/main.yml
+++ b/ansible/roles/dns/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Install BIND9
+  apt:
+    name: bind9
+    state: present
+  become: yes
+  tags: dns
+
+- name: Ensure BIND service is running
+  service:
+    name: bind9
+    state: started
+    enabled: true
+  become: yes
+  tags: dns

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Docker
+  apt:
+    name: docker.io
+    state: present
+  become: yes
+  tags: docker
+
+- name: Ensure Docker service is running
+  service:
+    name: docker
+    state: started
+    enabled: true
+  become: yes
+  tags: docker

--- a/ansible/roles/email/tasks/main.yml
+++ b/ansible/roles/email/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install Postfix and Dovecot
+  apt:
+    name:
+      - postfix
+      - dovecot-imapd
+    state: present
+  become: yes
+  tags: email
+
+- name: Ensure Postfix is running
+  service:
+    name: postfix
+    state: started
+    enabled: true
+  become: yes
+  tags: email
+
+- name: Ensure Dovecot is running
+  service:
+    name: dovecot
+    state: started
+    enabled: true
+  become: yes
+  tags: email

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install Prometheus and Grafana
+  apt:
+    name:
+      - prometheus
+      - grafana
+    state: present
+  become: yes
+  tags: monitoring
+
+- name: Ensure Prometheus is running
+  service:
+    name: prometheus
+    state: started
+    enabled: true
+  become: yes
+  tags: monitoring
+
+- name: Ensure Grafana is running
+  service:
+    name: grafana-server
+    state: started
+    enabled: true
+  become: yes
+  tags: monitoring

--- a/ansible/roles/tls/tasks/main.yml
+++ b/ansible/roles/tls/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install certbot
+  apt:
+    name: certbot
+    state: present
+  become: yes
+  tags: tls
+
+- name: Generate self-signed certificate
+  shell: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/selfsigned.key -out /etc/ssl/certs/selfsigned.crt -subj "/CN=example.com"
+  args:
+    creates: /etc/ssl/certs/selfsigned.crt
+  become: yes
+  tags: tls

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install Apache and PHP
+  apt:
+    name:
+      - apache2
+      - php
+      - libapache2-mod-php
+    state: present
+  become: yes
+  tags: web
+
+- name: Ensure Apache service is running
+  service:
+    name: apache2
+    state: started
+    enabled: true
+  become: yes
+  tags: web
+
+- name: Reminder to configure WordPress via UI
+  debug:
+    msg: "Open your browser and finish WordPress setup"
+  tags:
+    - web
+    - wordpress

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  become: true
+  roles:
+    - dns
+    - web
+    - email
+    - tls
+    - docker
+    - monitoring


### PR DESCRIPTION
## Summary
- add TODO list summarizing labs 1‑12
- document basic usage in README
- provide ansible folder structure with example roles
- include tasks for web, DNS, email, TLS, Docker and monitoring

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_684998bccc10832abb4a3c66265143b1