### PR TITLE
Add placeholder roles for labs 7-12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ To run all roles:
 
 ```bash
 cd ansible
-ansible-playbook site.yml
+ansible-playbook playbook.yml
 ```
 
 Run a single part using tags:
 
 ```bash
-ansible-playbook site.yml --tags web
+ansible-playbook playbook.yml --tags web
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@ This repository contains Ansible playbooks for automating tasks from the Univers
 Run specific parts of the infrastructure using tags, for example:
 
 ```bash
-ansible-playbook site.yml --tags email
+ansible-playbook playbook.yml --tags email
 ```
 
 If any configuration (such as WordPress initial setup) requires manual action, you will be prompted during playbook execution.

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -22,3 +22,9 @@
     - { role: dns,     tags: dns }
     - { role: apache,  tags: apache }
     - { role: mail,    tags: mail }
+    - { role: tls,     tags: tls }
+    - { role: filesystems, tags: fs }
+    - { role: containers, tags: containers }
+    - { role: devops, tags: devops }
+    - { role: kubernetes, tags: kubernetes }
+    - { role: monitoring, tags: monitoring }

--- a/ansible/roles/containers/tasks/main.yml
+++ b/ansible/roles/containers/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Containers | Install Docker
+  ansible.builtin.dnf:
+    name: docker
+    state: present
+
+- name: Containers | Start and enable Docker
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: yes
+
+- name: Containers | Pull hello-world image
+  ansible.builtin.command:
+    cmd: docker pull hello-world
+  changed_when: false

--- a/ansible/roles/devops/tasks/main.yml
+++ b/ansible/roles/devops/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: DevOps | Build example container
+  ansible.builtin.command:
+    cmd: docker build -t devops-example /usr/local/src/devops-example
+  args:
+    creates: /usr/local/src/devops-example
+  changed_when: false
+
+- name: DevOps | Run example container
+  ansible.builtin.command:
+    cmd: docker run --name devops-example -d devops-example
+  changed_when: false

--- a/ansible/roles/filesystems/tasks/main.yml
+++ b/ansible/roles/filesystems/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Filesystems | Install NFS and Samba packages
+  ansible.builtin.dnf:
+    name:
+      - nfs-utils
+      - samba
+    state: present
+
+- name: Filesystems | Ensure /srv/share exists
+  ansible.builtin.file:
+    path: /srv/share
+    state: directory
+    mode: '0755'
+
+- name: Filesystems | Export /srv/share over NFS
+  ansible.builtin.lineinfile:
+    path: /etc/exports
+    line: "/srv/share *(rw,sync,no_root_squash)"
+    create: yes
+
+- name: Filesystems | Restart NFS server
+  ansible.builtin.systemd:
+    name: nfs-server
+    state: restarted
+    enabled: yes
+
+- name: Filesystems | Configure Samba share
+  ansible.builtin.blockinfile:
+    path: /etc/samba/smb.conf
+    marker: "# {mark} ANSIBLE MANAGED share"
+    block: |
+      [share]
+      path = /srv/share
+      browsable = yes
+      read only = no
+
+- name: Filesystems | Restart smb service
+  ansible.builtin.systemd:
+    name: smb
+    state: restarted
+    enabled: yes

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Kubernetes | Install kubectl
+  ansible.builtin.dnf:
+    name: kubectl
+    state: present
+
+- name: Kubernetes | Deploy example nginx deployment
+  ansible.builtin.command:
+    cmd: kubectl apply -f https://k8s.io/examples/application/deployment.yaml
+  changed_when: false

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Monitoring | Install Prometheus and Grafana
+  ansible.builtin.dnf:
+    name:
+      - prometheus
+      - grafana
+    state: present
+
+- name: Monitoring | Start and enable Prometheus
+  ansible.builtin.systemd:
+    name: prometheus
+    state: started
+    enabled: yes
+
+- name: Monitoring | Start and enable Grafana
+  ansible.builtin.systemd:
+    name: grafana-server
+    state: started
+    enabled: yes

--- a/ansible/roles/tls/tasks/main.yml
+++ b/ansible/roles/tls/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: TLS | Install certbot
+  ansible.builtin.dnf:
+    name: certbot
+    state: present
+
+- name: TLS | Generate self-signed certificate for Apache
+  ansible.builtin.command:
+    cmd: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/pki/tls/private/selfsigned.key -out /etc/pki/tls/certs/selfsigned.crt -subj "/CN={{ hostname }}.{{ domain_name }}"
+  args:
+    creates: /etc/pki/tls/certs/selfsigned.crt
+
+- name: TLS | Ensure Apache listens on 443
+  ansible.builtin.lineinfile:
+    path: /etc/httpd/conf/httpd.conf
+    line: "Listen 443"
+    state: present
+  notify: Restart httpd


### PR DESCRIPTION
## Summary
- update instructions to use `playbook.yml`
- add placeholder Ansible roles for TLS, filesystems, containers, devops, kubernetes and monitoring
- extend playbook with new roles

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68499f5cb908832a8ecab627fa8052f4