### PR TITLE
Update DNS role to omit autoremove

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run all roles:
 
 ```bash
 cd ansible
-ansible-playbook playbook.yml
+ansible-playbook -i inventory/hosts playbook.yml
 ```
 
 Run a single part using tags:
@@ -16,3 +16,8 @@ Run a single part using tags:
 ```bash
 ansible-playbook playbook.yml --tags web
 ```
+
+The playbook expects that the target VM can reach the CentOS package
+repositories. If `dnf` fails with a `Cannot download repomd.xml` error,
+verify your network connectivity or configure a working mirror as
+described in the course lab manual.

--- a/ansible/roles/dns/tasks/main.yml
+++ b/ansible/roles/dns/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: DNS | Autoremove unneeded packages installed as dependencies
-  ansible.builtin.dnf:
-    autoremove: yes
-
 - name: DNS | Disable IPv6 - deploy sysctl conf
   ansible.builtin.copy:
     src: 70-ipv6.conf


### PR DESCRIPTION
## Summary
- remove the autoremove task from the DNS role
- keep instructions for running the playbook with inventory and repository note

## Testing
- ❌ `ansible-playbook playbook.yml --syntax-check` (failed to run: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6849a13160a8832a96e8e821b40cc4cf