### PR TITLE
Update DNS role to omit autoremove

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ Run a single part using tags:
 ```bash
 ansible-playbook playbook.yml --tags web
 ```
+
+The playbook expects that the target VM can reach the CentOS package
+repositories. If `dnf` fails with a `Cannot download repomd.xml` error,
+verify your network connectivity or configure a working mirror as
+described in the course lab manual.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = inventory/hosts

--- a/ansible/roles/dns/tasks/main.yml
+++ b/ansible/roles/dns/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: DNS | Autoremove unneeded packages installed as dependencies
-  ansible.builtin.dnf:
-    autoremove: yes
-
 - name: DNS | Disable IPv6 - deploy sysctl conf
   ansible.builtin.copy:
     src: 70-ipv6.conf

--- a/ansible/roles/mail/tasks/main.yml
+++ b/ansible/roles/mail/tasks/main.yml
@@ -199,41 +199,6 @@
     mode: '0644'
   notify: Restart postfix
 
-- name: Mail | Ensure Postfix is started and enabled
-  ansible.builtin.systemd:
-    name: postfix
-    state: started
-    enabled: yes
-
-# roles/mail/handlers/main.yml
-
-- name: Restart postfix
-  ansible.builtin.systemd:
-    name: postfix
-    state: restarted
-    enabled: yes
-
-############################
-# 6. Create a test user "mailuser"
-############################
-- name: Mail | Create mailuser account
-  ansible.builtin.user:
-    name: mailuser
-    comment: "Email test user"
-    shell: /bin/bash
-    create_home: yes
-    password: "{{ 'mailuser' | password_hash('sha512') }}"
-    state: present
-
-############################
-# 7. Send a local email (smoke test) from "mailuser" to "root"
-############################
-- name: Mail | Send a local test email
-  ansible.builtin.shell: |
-    echo "Test mail from mailuser on {{ ansible_fqdn }}" | sendmail root@localhost
-  args:
-    executable: /bin/bash
-
 ############################
 # 8. Dovecot configuration
 ############################
@@ -303,6 +268,27 @@
     name: dovecot
     state: started
     enabled: yes
+
+- name: Mail | Ensure Postfix is started and enabled
+  ansible.builtin.systemd:
+    name: postfix
+    state: started
+    enabled: yes
+
+- name: Mail | Create mailuser account
+  ansible.builtin.user:
+    name: mailuser
+    comment: "Email test user"
+    shell: /bin/bash
+    create_home: yes
+    password: "{{ 'mailuser' | password_hash('sha512') }}"
+    state: present
+
+- name: Mail | Send a local test email
+  ansible.builtin.shell: |
+    echo "Test mail from mailuser on {{ ansible_fqdn }}" | sendmail root@localhost
+  args:
+    executable: /bin/bash
 
 ############################
 # 9. Configure Postfix to hand off mail to Dovecot LMTP


### PR DESCRIPTION
## Summary
- remove the autoremove task from the DNS role
- keep instructions for running the playbook with inventory and repository note
- start Postfix only after Dovecot to avoid startup failure
- add `ansible.cfg` so the provided inventory is used automatically

## Testing
- `ansible-playbook playbook.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_6849a13160a8832a96e8e821b40cc4cf